### PR TITLE
feat!: added methods to determine the parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ This [Laravel Nova](https://nova.laravel.com/) package adds automated breadcrumb
 
 Whilst I have tested this package, I have not tested its interactions with every package out there, and in every environment possible. It currently has an 0.x version number due to its lack of tenure with regards to interactions outside of my environment more than anything else. 
 
+## 1.0.0 Breaking Changes
+
+1.0.0 introduces a breaking change in how the parent model is determined. The following is now applied in order:
+
+1) Attempt to get parent from the `parentMethod` method on the model
+2) Attempt to get parent from the first `Laravel\Nova\Fields\BelongsTo` field in your resource
+3) Attempt to get parent from the first method on your model that has a defined return type of `Illuminate\Database\Eloquent\Relations\BelongsTo`
+
+If none of these are fulfilled the package now optionally (defaulting to false):
+
+4) Attempt to find a `Laravel\Nova\Fields\BelongsTo` relationship via creating a blank model, invoking it's methods, and checking the type of the return.
+
+This was previously turned on by default if the `parentMethod` was not found, and had the potential to be destructive if there were methods on the model which were destructive across all records, such as `Model::truncate()`
+
+Please see the **Configuration Options** section below for more details on how to enable this functionality. 
+
 ## Requirements
 
 - `php: >=8.0`
@@ -116,6 +132,20 @@ These can be configured globally or chained to the Breadcrumbs class:
 
 #### Visibility and Authorisations
 Please see the [formfeed-uk/nova-resource-cards](https://github.com/Formfeed-UK/nova-resource-cards) package for information on the visbility and authorisation methods. They broadly follow the same pattern as fields.
+
+#### Invoking Reflection
+Determining the parent via invoking reflected blank model methods and checking the returned type is now disabled by default.
+
+It is highly recommended that this functionality be left off, and either a parent method, form field, or a defined relationship return type be used instead. 
+
+However if needed you can still enable this functionality by doing the following:
+
+- If downloading for the first time after 1.0.0 is released, set the `invokingReflection` configuration option after publishing the config
+- If upgrading from 0.1.x add the following to your config: `"invokingReflection" => true`
+
+You can also set this on a per-resource basis with the following static:
+
+`public static $invokingReflection = true|false;`
 
 ## Issues/Todo
 

--- a/config/breadcrumbs.php
+++ b/config/breadcrumbs.php
@@ -37,6 +37,33 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Use Invoking Reflection
+        |--------------------------------------------------------------------------
+        |
+        | If the package can't get the parent relationship from either a specified 
+        | "parent" method, a Nova/Fields/BelongsTo field, or a method with BelongsTo 
+        | return type on the underlying model, it will attempt to find the parent
+        | via creating a new blank model, invoking the methods, and reading the
+        | response types.
+        |
+        | If your model methods are designed reasonably, this should present no issue
+        | however if your model methods have destructive side effects for any reason
+        | such as "truncate" this could be problematic behaviour.
+        |
+        | As such from 1.0.0 this behaviour is disabled globally by default.
+        |
+        | It can be enabled globally by setting this to true, or on a per-resource
+        | basis by setting the following static on the resource:
+        |
+        | public static $invokingReflection = true|false;
+        |
+        | Default Value: false
+        |
+        */
+        "invokingReflection" => false,
+
+        /*
+        |--------------------------------------------------------------------------
         | Title Static Property
         |--------------------------------------------------------------------------
         |


### PR DESCRIPTION
- Added ability to determine parent via fields
- Added ability to determine parent via defined return type
- Set method of invoking methods to determine returntype to be disabled by default

BREAKING CHANGE: Disabling invoking by default could break parent model resolution on some installs