### PR TITLE
feat: can disable parent breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ This determines if the breadcrumb should link to the parent resource regardless 
 
 `public static $linkToParent = true|false;`
 
+#### Disable Parent Breadcrumbs
+Resolving Parent breadcrumbs can be disabled by adding the following static variable to a resource:
+
+`public static $resolveParentBreadcrumbs = false;`
+
 #### Extra CSS Classes
 These can be configured globally or chained to the Breadcrumbs class:
 

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -136,7 +136,7 @@ class Breadcrumbs extends ResourceCard {
                 ];
             }
             $array[] = $indexCrumb;
-            $this->getRelationshipTree($this->getParentModel($model), $array);
+            if (!property_exists($novaClass, "resolveParentBreadcrumbs") || $novaClass::$resolveParentBreadcrumbs !== false) $this->getRelationshipTree($this->getParentModel($model), $array);
         }
     }
 


### PR DESCRIPTION
- Adds feature to disable resolving parent breadcrumbs for a resource
- If set to false on a resource that resource will become the "top level" resource in a breadcrumbs array (before Home)