### PR TITLE
fix: issue with nova path duplicated in home path

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -260,11 +260,12 @@ class Breadcrumbs extends NovaBreadcrumbs {
     }
 
     protected function rootBreadcrumb(NovaRequest $request) {
+        $rootBreadcrumb = Breadcrumb::make(__("Home"), "/");
         if (!is_null(static::$rootBreadcrumbCallback)) {
-            return Arr::wrap(call_user_func_array(static::$rootBreadcrumbCallback, [$request, $this, Breadcrumb::make(__("Home"), config('nova.path', "/nova"))]));
+            return Arr::wrap(call_user_func_array(static::$rootBreadcrumbCallback, [$request, $this, $rootBreadcrumb]));
         }
 
-        return [Breadcrumb::make(__("Home"), config('nova.path', "/nova"))];
+        return [$rootBreadcrumb];
     }
 
     public function findResource(NovaRequest $request) {


### PR DESCRIPTION
Hello, I noticed that the path in the Home breadcrumb was duplicated, maybe because Nova changed something about how it generates paths. Feel free to use this if you want or let me know if there are any issues with the changes.