### PR TITLE
Update Breadcrumbs.php to fix traversable error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.4|^8",
-        "laravel/nova": "^4.19"
+        "laravel/nova": "^4.19|^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -35,7 +35,7 @@ class Breadcrumb extends NovaBreadcrumb {
      * @return static
      */
 
-    public static function resource($resourceClass) {
+    public static function resource($resourceClass): static {
         if ($resourceClass instanceof Resource && $resourceClass->model()->exists === true) {
             return static::detailResource($resourceClass);
         }

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -80,7 +80,7 @@ class Breadcrumbs extends NovaBreadcrumbs {
         if ($this->pageType($request) === "lens") {
             $lens = LensRequest::createFrom($request)->lens();
 
-            if (!is_null($lens) && property_exists($lens, "resolveParentBreadcrumbs") && $lens::$resolveParentBreadcrumbs === false)) {
+            if (!is_null($lens) && property_exists($lens, "resolveParentBreadcrumbs") && $lens::$resolveParentBreadcrumbs === false) {
                 array_push($this->items, ...$this->lensBreadcrumb($request));
                 return;
             }

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -213,7 +213,7 @@ class Breadcrumbs extends NovaBreadcrumbs {
         $dashboard = Nova::dashboardForKey($request->route("name"), $request);
 
         if (is_null($dashboard)) {
-            return;
+            return [];
         }
 
         if (method_exists($dashboard, "dashboardBreadcrumb")) {
@@ -232,7 +232,7 @@ class Breadcrumbs extends NovaBreadcrumbs {
         $lens = LensRequest::createFrom($request)->lens();
 
         if (is_null($lens)) {
-            return;
+            return [];
         }
 
         if (method_exists($lens, "lensBreadcrumb")) {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -77,6 +77,15 @@ class Breadcrumbs extends NovaBreadcrumbs {
 
         array_push($this->items, ...$this->rootBreadcrumb($request));
 
+        if ($this->pageType($request) === "lens") {
+            $lens = LensRequest::createFrom($request)->lens();
+
+            if (!is_null($lens) && property_exists($lens, "resolveParentBreadcrumbs") && $lens::$resolveParentBreadcrumbs === false)) {
+                array_push($this->items, ...$this->lensBreadcrumb($request));
+                return;
+            }
+        }
+
         if ($this->pageType($request) === "dashboard") {
             array_push($this->items, ...$this->dashboardBreadcrumb($request));
             return;


### PR DESCRIPTION
This fixes an error in while trying to visit a dashboard (or lens) that you don't have access to. The functions should return an array to allow array_merge to work correctly.