### PR TITLE
Check for routes cached as SerializableClosure

### DIFF
--- a/src/Http/Middleware/InterceptBreadcrumbs.php
+++ b/src/Http/Middleware/InterceptBreadcrumbs.php
@@ -22,8 +22,21 @@ class InterceptBreadcrumbs {
 
     public function handle(Request $request, Closure $next) {
 
-        if (array_key_exists("uses", $request->route()->action) && $request->route()->action['uses'] instanceof Closure) {
-            return $next($request);
+        if (array_key_exists("uses", $request->route()->action)) {
+
+            $uses = $request->route()->action['uses'];
+
+            // Routes can be cached as serialized \Laravel\SerializableClosure\SerializableClosure
+            try {
+                $uses = unserialize($uses)->getClosure();
+            } catch (\Exception) {
+                // PHP doesn't have a good way to check if a string is serialized
+                // unserialize() will either throw or return false on failure
+            }
+
+            if ($uses instanceof Closure) {
+                return $next($request);
+            }
         }
 
         $routeController = $request->route()->getController();

--- a/src/Http/Middleware/InterceptBreadcrumbs.php
+++ b/src/Http/Middleware/InterceptBreadcrumbs.php
@@ -27,11 +27,15 @@ class InterceptBreadcrumbs {
             $uses = $request->route()->action['uses'];
 
             // Routes can be cached as serialized \Laravel\SerializableClosure\SerializableClosure
-            try {
-                $uses = unserialize($uses)->getClosure();
-            } catch (\Exception) {
-                // PHP doesn't have a good way to check if a string is serialized
-                // unserialize() will either throw or return false on failure
+            if (is_string($uses)) {
+                try {
+                    $uses = unserialize($uses);
+                    if ($uses instanceof SerializableClosure) {
+                        $uses = $uses->getClosure();
+                    }
+                } catch (\Exception) {
+                    // PHP doesn't have a good way to check if a string is serialized
+                }
             }
 
             if ($uses instanceof Closure) {


### PR DESCRIPTION
Laravel: 9.52.7
Nova: 4.27.12

Nova 4 [custom tool](https://nova.laravel.com/docs/customization/tools.html) Inertia routes are cached as serialized `\Laravel\SerializableClosure\SerializableClosure` instances.

ex.
```
api.php

...
Route::get('/', function (NovaRequest $request) {
    return inertia('AdminReports');
});
...


routes-v7.php

...
'uses' => 'O:47:"Laravel\\SerializableClosure\\SerializableClosure":1:{s:12:"serializable";O:46:"Laravel\\SerializableClosure\\Serializers\\Signed":2:{s:12:"serializable";s:319:"O:46:"Laravel\\SerializableClosure\\Serializers\\Native":5:{s:3:"use";a:0:{}s:8:"function";s:100:"function (\\Laravel\\Nova\\Http\\Requests\\NovaRequest $request) {
    return \\inertia(\'AdminReports\');
}";s:5:"scope";s:37:"Illuminate\\Routing\\RouteFileRegistrar";s:4:"this";N;s:4:"self";s:32:"000000000000084f0000000000000000";}";s:4:"hash";s:44:"WfLjdBDYnFmCf7ZoX+kvA7cra30SXZb8DYUy/+O+9Y0=";}}',
...
```

This change adds an attempt to retrieve a `Closure` from a potential serialized `SerializableClosure` instance before the existing `instanceof Closure` check runs in the middleware.