### PR TITLE
Use getControllerClass() instead of getController()

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -282,8 +282,8 @@ class Breadcrumbs extends NovaBreadcrumbs {
     }
 
     protected function pageType(NovaRequest $request) {
-        $controller = $request->route()->getController();
-        switch ($controller::class) {
+        $controller = $request->route()->getControllerClass();
+        switch ($controller) {
             case Pages\ResourceDetailController::class:
                 return "detail";
             case Pages\ResourceIndexController::class:

--- a/src/Http/Middleware/InterceptBreadcrumbs.php
+++ b/src/Http/Middleware/InterceptBreadcrumbs.php
@@ -26,7 +26,7 @@ class InterceptBreadcrumbs {
             return $next($request);
         }
 
-        $routeController = $request->route()->getController();
+        $routeController = $request->route()->getControllerClass();
 
         if ( $this->isPageController($routeController) && Nova::breadcrumbsEnabled()) {
             $request = NovaRequest::createFrom($request);
@@ -58,7 +58,7 @@ class InterceptBreadcrumbs {
         return $breadcrumbs;
     }
 
-    protected function isPageController($controller) {
-        return ((new \ReflectionClass($controller))?->getNamespaceName() ?? false) === "Laravel\Nova\Http\Controllers\Pages";
+    protected function isPageController(?string $controllerClass) {
+        return str_starts_with($controllerClass, "Laravel\Nova\Http\Controllers\Pages");
     }
 }


### PR DESCRIPTION
`route()->getController()` is completely unsafe to use if the route uses a closure, and route()->isControllerAction() is protected. This leads to errors like `BindingResolutionException: Target class [] does not exist.` if a tool uses closures instead of controllers as they are turned into serialized closures. Therefore, the following code does not handle the cases correctly:
```php
if (array_key_exists("uses", $request->route()->action) && $request->route()->action['uses'] instanceof Closure) {
    return $next($request);
}
```
The function `getControllerClass()` is protected by the following function (in `Illuminate\Routing\Route`):
```php
    /**
     * Checks whether the route's action is a controller.
     *
     * @return bool
     */
    protected function isControllerAction()
    {
        return is_string($this->action['uses']) && ! $this->isSerializedClosure();
    }
```
I have rewritten the two occurrences of `route()->getController()` to use `getControllerClass()` instead.

Reference: https://github.com/wdelfuego/nova-calendar/issues/41#issuecomment-1326471351